### PR TITLE
update dependencies with npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -797,13 +797,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         }
       }
@@ -1018,9 +1018,9 @@
       "integrity": "sha512-RYkagUUbxQBss46ElbEa+j4q4X3GR12QwB7a/PM5hmVuVkYoW1jENT1+taspKUv8ibwW8cw+kRFbOaTc/Key3w=="
     },
     "@types/prop-types": {
-      "version": "15.7.0",
-      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.0.tgz",
-      "integrity": "sha512-eItQyV43bj4rR3JPV0Skpl1SncRCdziTEK9/v8VwXmV6d/qOUO8/EuWeHBbCZcsfSHfzI5UyMJLCSXtxxznyZg=="
+      "version": "15.7.1",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.1.tgz",
+      "integrity": "sha512-CFzn9idOEpHrgdw8JsoTkaDDyRWk1jrzIV8djzcgpq0y9tG4B4lFT+Nxh52DVpDXV+n4+NPNv7M1Dj5uMp6XFg=="
     },
     "@types/q": {
       "version": "1.5.2",
@@ -1028,9 +1028,9 @@
       "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw=="
     },
     "@types/reach__router": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.2.3.tgz",
-      "integrity": "sha512-Zp0AdVhoJXjwsgp8pDPVEMnAH5eHU64hi5EnPT1Jerddqwiy0O87KFrnZKd1DKdO87cU120n2d3SnKKPtf4wFA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.2.4.tgz",
+      "integrity": "sha512-a+MFhebeSGi0LwHZ0UhH/ke77rWtNQnt8YmaHnquSaY3HmyEi+BPQi3GhPcUPnC9X5BLw/qORw3BPxGb1mCtEw==",
       "requires": {
         "@types/history": "*",
         "@types/react": "*"
@@ -1334,37 +1334,6 @@
         "normalize-path": "^2.1.1"
       }
     },
-    "apollo-link": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.11.tgz",
-      "integrity": "sha512-PQvRCg13VduLy3X/0L79M6uOpTh5iHdxnxYuo8yL7sJlWybKRJwsv4IcRBJpMFbChOOaHY7Og9wgPo6DLKDKDA==",
-      "requires": {
-        "apollo-utilities": "^1.2.1",
-        "ts-invariant": "^0.3.2",
-        "tslib": "^1.9.3",
-        "zen-observable-ts": "^0.8.18"
-      }
-    },
-    "apollo-utilities": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.2.1.tgz",
-      "integrity": "sha512-Zv8Udp9XTSFiN8oyXOjf6PMHepD4yxxReLsl6dPUy5Ths7jti3nmlBzZUOxuTWRwZn0MoclqL7RQ5UEJN8MAxg==",
-      "requires": {
-        "fast-json-stable-stringify": "^2.0.0",
-        "ts-invariant": "^0.2.1",
-        "tslib": "^1.9.3"
-      },
-      "dependencies": {
-        "ts-invariant": {
-          "version": "0.2.1",
-          "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.2.1.tgz",
-          "integrity": "sha512-Z/JSxzVmhTo50I+LKagEISFJW3pvPCqsMWLamCTX8Kr3N5aMrnGOqcflbe5hLUzwjvgPfnLzQtHZv0yWQ+FIHg==",
-          "requires": {
-            "tslib": "^1.9.3"
-          }
-        }
-      }
-    },
     "aproba": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
@@ -1598,13 +1567,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         }
       }
@@ -2712,21 +2681,21 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         }
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000957",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000957.tgz",
-      "integrity": "sha512-8wxNrjAzyiHcLXN/iunskqQnJquQQ6VX8JHfW5kLgAPRSiSuKZiNfmIkP5j7jgyXqAQBSoXyJxfnbCFS0ThSiQ=="
+      "version": "1.0.30000962",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000962.tgz",
+      "integrity": "sha512-WXYsW38HK+6eaj5IZR16Rn91TGhU3OhbwjKZvJ4HN/XBIABLKfbij9Mnd3pM0VEwZSlltWjoWg3I8FQ0DGgNOA=="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -2888,6 +2857,31 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
+    },
+    "clipboardy": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
+      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
+      "requires": {
+        "arch": "^2.1.0",
+        "execa": "^0.8.0"
+      },
+      "dependencies": {
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "3.2.0",
@@ -3232,13 +3226,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         },
         "core-js": {
@@ -3657,9 +3651,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.3.tgz",
-      "integrity": "sha512-rINUZXOkcBmoHWEyu7JdHu5JMzkGRoMX4ov9830WNgxf5UYxcBUO0QTKAqeJ5EZfSdlrcJYkC8WwfVW7JYi4yg=="
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.4.tgz",
+      "integrity": "sha512-lAJUJP3M6HxFXbqtGRc0iZrdyeN+WzOWeY0q/VnFzI+kqVrYIzC7bWlKqCW7oCIdzoPkvfp82EVvrTlQ8zsWQg=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -3984,11 +3978,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "deprecated-decorator": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
-      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
     "des.js": {
       "version": "1.0.0",
@@ -4670,9 +4659,9 @@
       }
     },
     "eslint-module-utils": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.3.0.tgz",
-      "integrity": "sha512-lmDJgeOOjk8hObTysjqH7wyMi+nsHwwvfBykwfhjR1LNdd7C2uFJBvx4OpWYpXOw4df1yE1cDEVd1yLHitk34w==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.4.0.tgz",
+      "integrity": "sha512-14tltLm38Eu3zS+mt0KvILC3q8jyIAH518MlG+HO0p+yK885Lb1UHTY/UgR91eOyGdmxAPb+OLoW4znqIT6Ndw==",
       "requires": {
         "debug": "^2.6.8",
         "pkg-dir": "^2.0.0"
@@ -4710,29 +4699,30 @@
       }
     },
     "eslint-plugin-graphql": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-graphql/-/eslint-plugin-graphql-2.1.1.tgz",
-      "integrity": "sha512-JT2paUyu3e9ZDnroSshwUMc6pKcnkfXTsZInX1+/rPotvqOLVLtdrx/cmfb7PTJwjiEAshwcpm3/XPdTpsKJPw==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-graphql/-/eslint-plugin-graphql-3.0.3.tgz",
+      "integrity": "sha512-hHwLyxSkC5rkakJ/SNTWwOswPdVhvfyMCnEOloevrLQIOHUNVIQBg1ljCaRe9C40HdzgcGUFUdG5BHLCKm8tuw==",
       "requires": {
         "graphql-config": "^2.0.1",
         "lodash": "^4.11.1"
       }
     },
     "eslint-plugin-import": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.16.0.tgz",
-      "integrity": "sha512-z6oqWlf1x5GkHIFgrSvtmudnqM6Q60KM4KvpWi5ubonMjycLjndvd5+8VAZIsTlHC03djdgJuyKG6XO577px6A==",
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz",
+      "integrity": "sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==",
       "requires": {
+        "array-includes": "^3.0.3",
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
         "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.3.0",
+        "eslint-module-utils": "^2.4.0",
         "has": "^1.0.3",
         "lodash": "^4.17.11",
         "minimatch": "^3.0.4",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.9.0"
+        "resolve": "^1.10.0"
       },
       "dependencies": {
         "debug": {
@@ -5057,14 +5047,38 @@
       }
     },
     "express-graphql": {
-      "version": "0.6.12",
-      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.6.12.tgz",
-      "integrity": "sha512-ouLWV0hRw4hnaLtXzzwhdC79ewxKbY2PRvm05mPc/zOH5W5WVCHDQ1SmNxEPBQdUeeSNh29aIqW9zEQkA3kMuA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/express-graphql/-/express-graphql-0.7.1.tgz",
+      "integrity": "sha512-YpheAqTbSKpb5h57rV2yu2dPNUBi4FvZDspZ5iEV3ov34PBRgnM4lEBkv60+vZRJ6SweYL14N8AGYdov7g6ooQ==",
       "requires": {
-        "accepts": "^1.3.0",
+        "accepts": "^1.3.5",
         "content-type": "^1.0.4",
-        "http-errors": "^1.3.0",
-        "raw-body": "^2.3.2"
+        "http-errors": "^1.7.1",
+        "raw-body": "^2.3.3"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.7.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
+          "integrity": "sha512-uUQBt3H/cSIVfch6i1EuPNy/YsRSOUBXTVfZ+yR7Zjez3qjBz6i9+i4zjNaoqcoFVI4lQJ5plg63TvGfRSDCRg==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.1.1",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.0"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
+          "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "statuses": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+          "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+        }
       }
     },
     "ext-list": {
@@ -5581,7 +5595,8 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5599,11 +5614,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5616,15 +5633,18 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5727,7 +5747,8 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5737,6 +5758,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5749,17 +5771,20 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5776,6 +5801,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5848,7 +5874,8 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5858,6 +5885,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5933,7 +5961,8 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5963,6 +5992,7 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5980,6 +6010,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -6018,11 +6049,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         }
       }
     },
@@ -6037,9 +6070,9 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc="
     },
     "gatsby": {
-      "version": "2.3.16",
-      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.3.16.tgz",
-      "integrity": "sha512-wd3a3P1novSaoWPFO9pfPH6rUeUtKVWTaNRk4HgzluhQ4KtG63al3N/7joDe7KFSNJGLAft0pNlHftl3bBI+Ow==",
+      "version": "2.3.25",
+      "resolved": "https://registry.npmjs.org/gatsby/-/gatsby-2.3.25.tgz",
+      "integrity": "sha512-c14iiiGB84pYWwW4TTN8SVm7ffYaUtqEeN65pzMy345y6OJoQEUOkk7Cx2tpG4beRd6DwVfsgKAg4YQEnszcGg==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/core": "^7.0.0",
@@ -6084,29 +6117,28 @@
         "eslint-config-react-app": "^3.0.0",
         "eslint-loader": "^2.1.0",
         "eslint-plugin-flowtype": "^2.46.1",
-        "eslint-plugin-graphql": "^2.0.0",
+        "eslint-plugin-graphql": "^3.0.3",
         "eslint-plugin-import": "^2.9.0",
         "eslint-plugin-jsx-a11y": "^6.0.3",
         "eslint-plugin-react": "^7.8.2",
         "event-source-polyfill": "^1.0.5",
         "express": "^4.16.3",
-        "express-graphql": "^0.6.12",
+        "express-graphql": "^0.7.1",
         "fast-levenshtein": "~2.0.4",
         "file-loader": "^1.1.11",
         "flat": "^4.0.0",
         "fs-exists-cached": "1.0.0",
         "fs-extra": "^5.0.0",
-        "gatsby-cli": "^2.5.6",
+        "gatsby-cli": "^2.5.9",
         "gatsby-link": "^2.0.16",
         "gatsby-plugin-page-creator": "^2.0.12",
         "gatsby-react-router-scroll": "^2.0.7",
-        "gatsby-telemetry": "^1.0.6",
+        "gatsby-telemetry": "^1.0.7",
         "glob": "^7.1.1",
+        "got": "8.0.0",
         "graphql": "^14.1.1",
-        "graphql-compose": "^6.0.3",
+        "graphql-compose": "6.0.3",
         "graphql-playground-middleware-express": "^1.7.10",
-        "graphql-relay": "^0.6.0",
-        "graphql-tools": "^3.0.4",
         "hash-mod": "^0.0.5",
         "invariant": "^2.2.4",
         "is-relative": "^1.0.0",
@@ -6141,7 +6173,6 @@
         "react-error-overlay": "^3.0.0",
         "react-hot-loader": "^4.6.2",
         "redux": "^4.0.0",
-        "request": "^2.85.0",
         "semver": "^5.6.0",
         "shallow-compare": "^1.2.2",
         "sift": "^5.1.0",
@@ -6188,6 +6219,19 @@
             "wrap-ansi": "^2.0.0"
           }
         },
+        "configstore": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/configstore/-/configstore-4.0.0.tgz",
+          "integrity": "sha512-CmquAXFBocrzaSM8mtGPMM/HiWmyIpr4CcJl/rgY2uCObZ/S7cKU0silxslqJejl+t/T9HS8E0PUNQD81JGUEQ==",
+          "requires": {
+            "dot-prop": "^4.1.0",
+            "graceful-fs": "^4.1.2",
+            "make-dir": "^1.0.0",
+            "unique-string": "^1.0.0",
+            "write-file-atomic": "^2.0.0",
+            "xdg-basedir": "^3.0.0"
+          }
+        },
         "execa": {
           "version": "0.8.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
@@ -6211,27 +6255,32 @@
           }
         },
         "gatsby-cli": {
-          "version": "2.5.6",
-          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.5.6.tgz",
-          "integrity": "sha512-QPV1ST0SHB9X4FzI9M/uDrtf70/opjmo+EdbZxxwQOy6GWEZn3FDl4Ix+nlzY16WZlieJV4fmDcmz+nkBb/pDw==",
+          "version": "2.5.9",
+          "resolved": "https://registry.npmjs.org/gatsby-cli/-/gatsby-cli-2.5.9.tgz",
+          "integrity": "sha512-Z7kPib4fUaSLTd/1EBxsKgT55sVhy2fNmL6wnWqfkk2O4CLWhG0nAqqKrumPWQQqZAYZDFDHycb05VbDfDpmRg==",
           "requires": {
             "@babel/code-frame": "^7.0.0",
             "@babel/runtime": "^7.0.0",
             "bluebird": "^3.5.0",
+            "ci-info": "^2.0.0",
+            "clipboardy": "^1.2.3",
             "common-tags": "^1.4.0",
+            "configstore": "^4.0.0",
             "convert-hrtime": "^2.0.0",
             "core-js": "^2.5.0",
             "envinfo": "^5.8.1",
             "execa": "^0.8.0",
             "fs-exists-cached": "^1.0.0",
             "fs-extra": "^4.0.1",
-            "gatsby-telemetry": "^1.0.6",
+            "gatsby-telemetry": "^1.0.7",
             "hosted-git-info": "^2.6.0",
+            "is-valid-path": "^0.1.1",
             "lodash": "^4.17.10",
             "meant": "^1.0.1",
             "node-fetch": "2.3.0",
             "opentracing": "^0.14.3",
             "pretty-error": "^2.1.1",
+            "prompts": "^2.0.4",
             "resolve-cwd": "^2.0.0",
             "source-map": "^0.5.7",
             "stack-trace": "^0.0.10",
@@ -6273,6 +6322,14 @@
           "requires": {
             "p-locate": "^3.0.0",
             "path-exists": "^3.0.0"
+          }
+        },
+        "make-dir": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
+          "requires": {
+            "pify": "^3.0.0"
           }
         },
         "mem": {
@@ -6361,6 +6418,11 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "strip-ansi": {
           "version": "4.0.0",
@@ -6625,15 +6687,15 @@
       }
     },
     "gatsby-telemetry": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.0.6.tgz",
-      "integrity": "sha512-3j/pLm9VAgEanmQ56XggX6L/3V+w9sjUn+4Jn9Bm9nuBvqujsgOuBAlTYoySP0tjVliXDsmKQCnfF8cMErXOLQ==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/gatsby-telemetry/-/gatsby-telemetry-1.0.7.tgz",
+      "integrity": "sha512-KVxIifmJWDaaXEKXTUVaXkmlY+y7wiIAjLuvcl+SBEhYGiJ/Obq4VrjUU4uGsj5d+4+loPvzvBv1LoKuw+CqLw==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "@babel/runtime": "^7.0.0",
         "bluebird": "^3.5.0",
         "ci-info": "2.0.0",
-        "configstore": "4.0.0",
+        "configstore": "^4.0.0",
         "envinfo": "^5.8.1",
         "fs-extra": "^7.0.1",
         "is-docker": "1.1.0",
@@ -6885,21 +6947,48 @@
       }
     },
     "got": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
-      "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-8.0.0.tgz",
+      "integrity": "sha512-lqVA9ORcSGfJPHfMXh1RW451aYMP1NyXivpGqGggnfDqNz3QVfMl7MkuEz+dr70gK2X8dhLiS5YzHhCV3/3yOQ==",
       "requires": {
-        "create-error-class": "^3.0.0",
+        "cacheable-request": "^2.1.1",
+        "decompress-response": "^3.3.0",
         "duplexer3": "^0.1.4",
         "get-stream": "^3.0.0",
-        "is-redirect": "^1.0.0",
-        "is-retry-allowed": "^1.0.0",
-        "is-stream": "^1.0.0",
+        "into-stream": "^3.1.0",
+        "is-plain-obj": "^1.1.0",
+        "is-retry-allowed": "^1.1.0",
+        "is-stream": "^1.1.0",
+        "isurl": "^1.0.0-alpha5",
         "lowercase-keys": "^1.0.0",
-        "safe-buffer": "^5.0.1",
-        "timed-out": "^4.0.0",
-        "unzip-response": "^2.0.1",
-        "url-parse-lax": "^1.0.0"
+        "mimic-response": "^1.0.0",
+        "p-cancelable": "^0.3.0",
+        "p-timeout": "^1.2.0",
+        "pify": "^3.0.0",
+        "safe-buffer": "^5.1.1",
+        "timed-out": "^4.0.1",
+        "url-parse-lax": "^3.0.0",
+        "url-to-options": "^1.0.1"
+      },
+      "dependencies": {
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+        },
+        "prepend-http": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
+          "integrity": "sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc="
+        },
+        "url-parse-lax": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
+          "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
+          "requires": {
+            "prepend-http": "^2.0.0"
+          }
+        }
       }
     },
     "graceful-fs": {
@@ -6921,11 +7010,11 @@
       }
     },
     "graphql-compose": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/graphql-compose/-/graphql-compose-6.2.0.tgz",
-      "integrity": "sha512-DuxSGduPxkFQbfr1XZcOqYC5ifmNea9zgJ924ugpNZfXWT9iQTaUiXQFZ4JM6AWkp3VHI7xwg3t7KN0tGLv1EA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/graphql-compose/-/graphql-compose-6.0.3.tgz",
+      "integrity": "sha512-QpywEtNvlEQS0a5VIseMA/tk67QmEN9NNUx1B1tzGR/p7MePyus9wvci2cIP/mwdDrvLRRbwpmidSKQXFD3SEA==",
       "requires": {
-        "graphql-type-json": "^0.2.4",
+        "graphql-type-json": "^0.2.1",
         "object-path": "^0.11.4"
       }
     },
@@ -6970,32 +7059,12 @@
         "graphql-playground-html": "1.6.12"
       }
     },
-    "graphql-relay": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/graphql-relay/-/graphql-relay-0.6.0.tgz",
-      "integrity": "sha512-OVDi6C9/qOT542Q3KxZdXja3NrDvqzbihn1B44PH8P/c5s0Q90RyQwT6guhGqXqbYEH6zbeLJWjQqiYvcg2vVw==",
-      "requires": {
-        "prettier": "^1.16.0"
-      }
-    },
     "graphql-request": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-1.8.2.tgz",
       "integrity": "sha512-dDX2M+VMsxXFCmUX0Vo0TopIZIX4ggzOtiCsThgtrKR4niiaagsGTDIHj3fsOMFETpa064vzovI+4YV4QnMbcg==",
       "requires": {
         "cross-fetch": "2.2.2"
-      }
-    },
-    "graphql-tools": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-3.1.1.tgz",
-      "integrity": "sha512-yHvPkweUB0+Q/GWH5wIG60bpt8CTwBklCSzQdEHmRUgAdEQKxw+9B7zB3dG7wB3Ym7M7lfrS4Ej+jtDZfA2UXg==",
-      "requires": {
-        "apollo-link": "^1.2.2",
-        "apollo-utilities": "^1.0.1",
-        "deprecated-decorator": "^0.1.6",
-        "iterall": "^1.1.3",
-        "uuid": "^3.1.0"
       }
     },
     "graphql-type-json": {
@@ -7611,9 +7680,9 @@
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
     },
     "inquirer": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
       "requires": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -7626,7 +7695,7 @@
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
         "string-width": "^2.1.0",
-        "strip-ansi": "^5.0.0",
+        "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       },
       "dependencies": {
@@ -7652,13 +7721,6 @@
       "requires": {
         "default-gateway": "^4.2.0",
         "ipaddr.js": "^1.9.0"
-      },
-      "dependencies": {
-        "ipaddr.js": {
-          "version": "1.9.0",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
-          "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
-        }
       }
     },
     "into-stream": {
@@ -7701,9 +7763,9 @@
       "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
     },
     "ipaddr.js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.0.tgz",
+      "integrity": "sha512-M4Sjn6N/+O6/IXSJseKqHoFc+5FdGJ22sXqnjTpdZweHK64MzEPAyQZyEU3R/KRv2GLoa7nNtg/C2Ev6m7z+eA=="
     },
     "is-absolute": {
       "version": "1.0.0",
@@ -7909,6 +7971,29 @@
         "is-path-inside": "^1.0.0"
       }
     },
+    "is-invalid-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+      "integrity": "sha1-MHqFWzzxqTi0TqcNLGEQYFNxTzQ=",
+      "requires": {
+        "is-glob": "^2.0.0"
+      },
+      "dependencies": {
+        "is-extglob": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+          "integrity": "sha1-rEaBd8SUNAWgkvyPKXYMb/xiBsA="
+        },
+        "is-glob": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+          "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
+          "requires": {
+            "is-extglob": "^1.0.0"
+          }
+        }
+      }
+    },
     "is-jpg": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-jpg/-/is-jpg-2.0.0.tgz",
@@ -8084,6 +8169,14 @@
       "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
       "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
     },
+    "is-valid-path": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+      "integrity": "sha1-EQ+f90w39mPh7HkV60UfLbk6yd8=",
+      "requires": {
+        "is-invalid-path": "^0.1.0"
+      }
+    },
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
@@ -8214,9 +8307,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.13.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.0.tgz",
-      "integrity": "sha512-pZZoSxcCYco+DIKBTimr67J6Hy+EYGZDY/HCWC+iAEA9h1ByhMXAIVUXMcMFpOCxQ/xjXmPI2MkDL5HRm5eFrQ==",
+      "version": "3.13.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
+      "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -8337,6 +8430,11 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
+    },
+    "kleur": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
+      "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w=="
     },
     "last-call-webpack-plugin": {
       "version": "3.0.0",
@@ -9265,9 +9363,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.13.tgz",
-      "integrity": "sha512-fKZGviSXR6YvVPyc011NHuJDSD8gFQvLPmc2d2V3BS4gr52ycyQ1Xzs7a8B+Ax3Ni/W+5h1h4SqmzeoA8WZRmA==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.15.tgz",
+      "integrity": "sha512-cKV097BQaZr8LTSRUa2+oc/aX5L8UkZtPQrMSTgiJEeaW7ymTDCoRaGCoaTqk0lqnalcoSHu4wjSl0Cmj2+bMw==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -9710,6 +9808,26 @@
         "registry-auth-token": "^3.0.1",
         "registry-url": "^3.0.3",
         "semver": "^5.1.0"
+      },
+      "dependencies": {
+        "got": {
+          "version": "6.7.1",
+          "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "requires": {
+            "create-error-class": "^3.0.0",
+            "duplexer3": "^0.1.4",
+            "get-stream": "^3.0.0",
+            "is-redirect": "^1.0.0",
+            "is-retry-allowed": "^1.0.0",
+            "is-stream": "^1.0.0",
+            "lowercase-keys": "^1.0.0",
+            "safe-buffer": "^5.0.1",
+            "timed-out": "^4.0.0",
+            "unzip-response": "^2.0.1",
+            "url-parse-lax": "^1.0.0"
+          }
+        }
       }
     },
     "pako": {
@@ -9831,9 +9949,9 @@
       }
     },
     "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "pascalcase": {
       "version": "0.1.1",
@@ -10143,13 +10261,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         }
       }
@@ -10304,13 +10422,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         },
         "postcss-selector-parser": {
@@ -10359,13 +10477,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         }
       }
@@ -10567,13 +10685,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         }
       }
@@ -10620,13 +10738,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         }
       }
@@ -10750,7 +10868,8 @@
     "prettier": {
       "version": "1.17.0",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
-      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw=="
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "4.0.2",
@@ -10812,6 +10931,15 @@
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
     },
+    "prompts": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.0.4.tgz",
+      "integrity": "sha512-HTzM3UWp/99A0gk51gAegwo1QRYA7xjcZufMNe33rCclFszUYAuHe1fIN/3ZmiHeGPkUsNaRyQm1hHOfM0PKxA==",
+      "requires": {
+        "kleur": "^3.0.2",
+        "sisteransi": "^1.0.0"
+      }
+    },
     "prop-types": {
       "version": "15.7.2",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
@@ -10828,12 +10956,12 @@
       "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
     },
     "proxy-addr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.5.tgz",
+      "integrity": "sha512-t/7RxHXPH6cJtP0pRG6smSr9QJidhB+3kXu0KgXnbGYMgzEnUxRQ4/LDdfOwZEMyIh3/xHb8PX3t+lfL9z+YVQ==",
       "requires": {
         "forwarded": "~0.1.2",
-        "ipaddr.js": "1.8.0"
+        "ipaddr.js": "1.9.0"
       }
     },
     "prr": {
@@ -11196,9 +11324,9 @@
       }
     },
     "react-hot-loader": {
-      "version": "4.8.3",
-      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.8.3.tgz",
-      "integrity": "sha512-Is8bKbSxuDLTqsWu1yjr+o1yA6yGDGjEQ2i1E8t/Nj1xJYC6QBRbyoofTn1xkMoKpcgXHuTJTqBhK0RY6moFJA==",
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/react-hot-loader/-/react-hot-loader-4.8.4.tgz",
+      "integrity": "sha512-O98btZXcm24ZgP+aPBD0W9N+GEnkOg6vlLEy/IMZ53u3K/dGqO0I/RU4qrmQzE+wMDLpwNo5TwxaAjVw9Y+IBA==",
       "requires": {
         "fast-levenshtein": "^2.0.6",
         "global": "^4.3.0",
@@ -11867,9 +11995,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.6.1.tgz",
-      "integrity": "sha512-A5MOagrPFga4YaKQSWHryl7AXvbQkEqpw4NNYMTNYUNV51bA8ABHgYFpqKx+YFFrw59xMV1qGH1R4AgoNIVgCw=="
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
+      "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA=="
     },
     "serve-index": {
       "version": "1.9.1",
@@ -12052,6 +12180,11 @@
           "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
         }
       }
+    },
+    "sisteransi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.0.tgz",
+      "integrity": "sha512-N+z4pHB4AmUv0SjveWRd6q1Nj5w62m5jodv+GD8lvmbY/83T/rpbJGZOnK5T149OldDj4Db07BSv9xY4K6NTPQ=="
     },
     "slash": {
       "version": "1.0.0",
@@ -12822,13 +12955,13 @@
       },
       "dependencies": {
         "browserslist": {
-          "version": "4.5.4",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.4.tgz",
-          "integrity": "sha512-rAjx494LMjqKnMPhFkuLmLp8JWEX0o8ADTGeAbOqaF+XCvYLreZrG5uVjnPBlAQ8REZK4pzXGvp0bWgrFtKaag==",
+          "version": "4.5.5",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.5.tgz",
+          "integrity": "sha512-0QFO1r/2c792Ohkit5XI8Cm8pDtZxgNl2H6HU4mHrpYz7314pEYcsAVVatM0l/YmxPnEzh9VygXouj4gkFUTKA==",
           "requires": {
-            "caniuse-lite": "^1.0.30000955",
-            "electron-to-chromium": "^1.3.122",
-            "node-releases": "^1.1.13"
+            "caniuse-lite": "^1.0.30000960",
+            "electron-to-chromium": "^1.3.124",
+            "node-releases": "^1.1.14"
           }
         },
         "postcss-selector-parser": {
@@ -12951,9 +13084,9 @@
       }
     },
     "tapable": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.1.tgz",
-      "integrity": "sha512-9I2ydhj8Z9veORCw5PRm4u9uebCn0mcCa6scWoNcbZ6dAtoo2618u9UUzxgmsCOreJpqDDuv61LvwofW7hLcBA=="
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar": {
       "version": "4.4.8",
@@ -13196,6 +13329,11 @@
         "repeat-string": "^1.6.1"
       }
     },
+    "toidentifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.0.tgz",
+      "integrity": "sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw=="
+    },
     "topo": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
@@ -13246,18 +13384,10 @@
         "glob": "^7.1.2"
       }
     },
-    "ts-invariant": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.3.3.tgz",
-      "integrity": "sha512-UReOKsrJFGC9tUblgSRWo+BsVNbEd77Cl6WiV/XpMlkifXwNIJbknViCucHvVZkXSC/mcWeRnIGdY7uprcwvdQ==",
-      "requires": {
-        "tslib": "^1.9.3"
-      }
-    },
     "ts-pnp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.0.1.tgz",
-      "integrity": "sha512-Zzg9XH0anaqhNSlDRibNC8Kp+B9KNM0uRIpLpGkGyrgRIttA7zZBhotTSEoEyuDrz3QW2LGtu2dxuk34HzIGnQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.1.0.tgz",
+      "integrity": "sha512-hJkGMrHwSZtk6gsRR3GUXBQ2vFTdO9SgL/e+rNFyvBsBLKl1J6bjRGt5+NW2f5yRTMW8so58nwvvs93nqi5sGw=="
     },
     "tslib": {
       "version": "1.9.3",
@@ -13564,9 +13694,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.4.tgz",
-      "integrity": "sha512-/92DTTorg4JjktLNLe6GPS2/RvAd/RGr6LuktmWSMLEOa6rjnlrFXNgSbSmkNvCoL2T028A0a1JaJLzRMlFoHg==",
+      "version": "1.4.6",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.6.tgz",
+      "integrity": "sha512-/B8AD9iQ01seoXmXf9z/MjLZQIdOoYl/+gvsQF6+mpnxaTfG9P7srYaiqaDMyKkR36XMXfhqSHss5MyFAO8lew==",
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"
@@ -13774,9 +13904,9 @@
       }
     },
     "webpack-dev-server": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.3.0.tgz",
-      "integrity": "sha512-75LTgV367MRDVIC+IBETrKEy9175+i5fy9nkw8MW+udnPCzNzSfZtKUIG5thQcooaNruPZZoEV8fCZqKJszOIw==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-3.3.1.tgz",
+      "integrity": "sha512-jY09LikOyGZrxVTXK0mgIq9y2IhCoJ05848dKZqX1gAGLU1YDqgpOT71+W53JH/wI4v6ky4hm+KvSyW14JEs5A==",
       "requires": {
         "ansi-html": "0.0.7",
         "bonjour": "^3.5.0",
@@ -14491,9 +14621,9 @@
       "integrity": "sha1-wodrBhaKrcQOV9l+gRkayPQ5iz4="
     },
     "xstate": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.4.0.tgz",
-      "integrity": "sha512-MS638X5zCzEAZA/UOW9fUHSg4xAGfiHFkGMjtU5j/gmb1PtGBAVImv0iWqRZNwVqTALxxtQz655BVyNSNz2ThA=="
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/xstate/-/xstate-4.5.0.tgz",
+      "integrity": "sha512-7vShhDqfYUWTb1NXZFjk61KTIg6Gi3r21P0M6ApAPCYTJP+pLtbu+uD5Vxaae8Nz21cSu3/OZfvMqN88AkJpHw=="
     },
     "xtend": {
       "version": "4.0.1",
@@ -14615,20 +14745,6 @@
             "ansi-regex": "^4.1.0"
           }
         }
-      }
-    },
-    "zen-observable": {
-      "version": "0.8.13",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.13.tgz",
-      "integrity": "sha512-fa+6aDUVvavYsefZw0zaZ/v3ckEtMgCFi30sn91SEZea4y/6jQp05E3omjkX91zV6RVdn15fqnFZ6RKjRGbp2g=="
-    },
-    "zen-observable-ts": {
-      "version": "0.8.18",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.18.tgz",
-      "integrity": "sha512-q7d05s75Rn1j39U5Oapg3HI2wzriVwERVo4N7uFGpIYuHB9ff02P/E92P9B8T7QVC93jCMHpbXH7X0eVR5LA7A==",
-      "requires": {
-        "tslib": "^1.9.3",
-        "zen-observable": "^0.8.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "babel-plugin-styled-components": "^1.10.0",
     "bootstrap": "^4.3.1",
     "color": "^3.1.0",
-    "gatsby": "^2.3.16",
+    "gatsby": "^2.3.25",
     "gatsby-image": "^2.0.37",
     "gatsby-plugin-manifest": "^2.0.28",
     "gatsby-plugin-offline": "^2.0.25",


### PR DESCRIPTION
When I ran `npm install`, there were eight vulnerable dependencies detected.  I ran `npm audit fix` to update them. 